### PR TITLE
Usecaseの作成リファクタリング

### DIFF
--- a/src/app/Exception/InputErrorExeception.php
+++ b/src/app/Exception/InputErrorExeception.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Exception;
+
+use Exception;
+
+final class InputErrorExeception extends Exception
+{
+    private $errors;
+
+    public function setErrors(array $errors): self
+    {
+        $this->errors = $errors;
+        return $this;
+    }
+    public function getErrors(): ?array
+    {
+        return $this->errors ?? null;
+    }
+}

--- a/src/app/Infrastructure/Dao/AuthSessionDao.php
+++ b/src/app/Infrastructure/Dao/AuthSessionDao.php
@@ -4,6 +4,11 @@ namespace App\Infrastructure\Dao;
 final class AuthSessionDao
 {
     const SESSION_NAME = 'auth';
+
+    /**
+     * Signinユーザーの情報を取得
+     * @return array | null
+     */
     public function getSigninUser(): ?array
     {
         if (isset($_SESSION[self::SESSION_NAME])) {
@@ -11,6 +16,12 @@ final class AuthSessionDao
         }
         return null;
     }
+
+    /**
+     * Signinユーザーの情報を設定
+     * @param string $id
+     * @param string $name
+     */
     public function setSigninUser(string $id, string $name): void
     {
         $_SESSION[self::SESSION_NAME] = ['id' => $id, 'name' => $name];

--- a/src/app/Infrastructure/Dao/AuthSessionDao.php
+++ b/src/app/Infrastructure/Dao/AuthSessionDao.php
@@ -1,17 +1,17 @@
 <?php
 namespace App\Infrastructure\Dao;
 
-final class LoginSessionDao
+final class AuthSessionDao
 {
-    const SESSION_NAME = 'login';
-    public function getLoginUser(): ?array
+    const SESSION_NAME = 'auth';
+    public function getSigninUser(): ?array
     {
         if (isset($_SESSION[self::SESSION_NAME])) {
             return $_SESSION[self::SESSION_NAME];
         }
         return null;
     }
-    public function setLoginUser(string $id, string $name): void
+    public function setSigninUser(string $id, string $name): void
     {
         $_SESSION[self::SESSION_NAME] = ['id' => $id, 'name' => $name];
     }

--- a/src/app/Infrastructure/Dao/ErrorsSessionDao.php
+++ b/src/app/Infrastructure/Dao/ErrorsSessionDao.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Infrastructure\Dao;
+
+final class ErrorsSessionDao
+{
+    const SESSION_NAME = 'errors';
+
+    private $errors;
+
+    public function __construct()
+    {
+        $this->errors = $_SESSION[self::SESSION_NAME] ?? [];
+        unset($_SESSION[self::SESSION_NAME]);
+    }
+
+    /**
+     * 入力エラーの取得
+     * @return array | null
+     */
+    public function getErrors(): ?array
+    {
+        if (!empty($this->errors)) {
+            return $this->errors;
+        }
+        return null;
+    }
+
+    /**
+     * 入力エラーの設定
+     * @param array $errors
+     */
+    public function setErrors(array $errors): void
+    {
+        $this->errors = $errors;
+        $_SESSION[self::SESSION_NAME] = $errors;
+    }
+}

--- a/src/app/Infrastructure/Dao/FormDataSessionDao.php
+++ b/src/app/Infrastructure/Dao/FormDataSessionDao.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Infrastructure\Dao;
+
+final class FormDataSessionDao
+{
+    const SESSION_NAME = 'formData';
+
+    private $formData;
+
+    public function __construct()
+    {
+        $this->formData = $_SESSION[self::SESSION_NAME] ?? [];
+        unset($_SESSION[self::SESSION_NAME]);
+    }
+
+    /**
+     * フォーム入力値の取得
+     * @return array | null
+     */
+    public function getFormData(): ?array
+    {
+        if (!empty($this->formData)) {
+            return $this->formData;
+        }
+        return null;
+    }
+
+    /**
+     * フォーム入力値の設定
+     * @param array $formData
+     */
+    public function setFormData(array $formData): void
+    {
+        $this->formData = $formData;
+        $_SESSION[self::SESSION_NAME] = $formData;
+    }
+}

--- a/src/app/Infrastructure/Dao/LoginSessionDao.php
+++ b/src/app/Infrastructure/Dao/LoginSessionDao.php
@@ -11,8 +11,8 @@ final class LoginSessionDao
         }
         return null;
     }
-    public function setLoginUser(string $name, string $email): void
+    public function setLoginUser(string $id, string $name): void
     {
-        $_SESSION[self::SESSION_NAME] = ['name' => $name, 'email' => $email];
+        $_SESSION[self::SESSION_NAME] = ['id' => $id, 'name' => $name];
     }
 }

--- a/src/app/Infrastructure/Dao/MessagesSessionDao.php
+++ b/src/app/Infrastructure/Dao/MessagesSessionDao.php
@@ -13,6 +13,10 @@ final class MessagesSessionDao
         unset($_SESSION[self::SESSION_NAME]);
     }
 
+    /**
+     * flashメッセージの取得
+     * @return array | null
+     */
     public function getMessages(): ?array
     {
         if (!empty($this->messages)) {
@@ -21,6 +25,10 @@ final class MessagesSessionDao
         return null;
     }
 
+    /**
+     * flashメッセージの設定
+     * @param string $message
+     */
     public function setMessage(string $message): void
     {
         $_SESSION[self::SESSION_NAME][] = $message;

--- a/src/app/Infrastructure/Dao/MessagesSessionDao.php
+++ b/src/app/Infrastructure/Dao/MessagesSessionDao.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Infrastructure\Dao;
+
+final class MessagesSessionDao
+{
+    const SESSION_NAME = 'messages';
+
+    private $messages = [];
+
+    public function __construct()
+    {
+        $this->messages = $_SESSION[self::SESSION_NAME];
+        unset($_SESSION[self::SESSION_NAME]);
+    }
+
+    public function getMessages(): ?array
+    {
+        if (!empty($this->messages)) {
+            return $this->messages;
+        }
+        return null;
+    }
+
+    public function setMessage(string $message): void
+    {
+        $_SESSION[self::SESSION_NAME][] = $message;
+    }
+}

--- a/src/app/Infrastructure/Dao/MessagesSessionDao.php
+++ b/src/app/Infrastructure/Dao/MessagesSessionDao.php
@@ -5,11 +5,11 @@ final class MessagesSessionDao
 {
     const SESSION_NAME = 'messages';
 
-    private $messages = [];
+    private $messages;
 
     public function __construct()
     {
-        $this->messages = $_SESSION[self::SESSION_NAME];
+        $this->messages = $_SESSION[self::SESSION_NAME] ?? [];
         unset($_SESSION[self::SESSION_NAME]);
     }
 
@@ -31,6 +31,7 @@ final class MessagesSessionDao
      */
     public function setMessage(string $message): void
     {
+        $this->messages[] = $message;
         $_SESSION[self::SESSION_NAME][] = $message;
     }
 }

--- a/src/app/Usecase/UsecaseInput/SigninInput.php
+++ b/src/app/Usecase/UsecaseInput/SigninInput.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\UseCase\UseCaseInput;
+
+final class SigninInput
+{
+    private $email;
+    private $password;
+
+    public function __construct(string $email, string $password)
+    {
+        $this->email = $email;
+        $this->password = $password;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}

--- a/src/app/Usecase/UsecaseInput/SigninInput.php
+++ b/src/app/Usecase/UsecaseInput/SigninInput.php
@@ -12,11 +12,19 @@ final class SigninInput
         $this->password = $password;
     }
 
+    /**
+     * email入力を取得
+     * @return string
+     */
     public function getEmail(): string
     {
         return $this->email;
     }
 
+    /**
+     * password入力を取得
+     * @return string
+     */
     public function getPassword(): string
     {
         return $this->password;

--- a/src/app/Usecase/UsecaseInput/SignupInput.php
+++ b/src/app/Usecase/UsecaseInput/SignupInput.php
@@ -14,16 +14,28 @@ final class SignupInput
         $this->password = $password;
     }
 
+    /**
+     * name入力を取得
+     * @return string
+     */
     public function getName(): string
     {
         return $this->name;
     }
 
+    /**
+     * email入力を取得
+     * @return string
+     */
     public function getEmail(): string
     {
         return $this->email;
     }
 
+    /**
+     * password入力を取得
+     * @return string
+     */
     public function getPassword(): string
     {
         return $this->password;

--- a/src/app/Usecase/UsecaseInput/SignupInput.php
+++ b/src/app/Usecase/UsecaseInput/SignupInput.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\UseCase\UseCaseInput;
+
+final class SignupInput
+{
+    private $name;
+    private $email;
+    private $password;
+
+    public function __construct(string $name, string $email, string $password)
+    {
+        $this->name = $name;
+        $this->email = $email;
+        $this->password = $password;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+}

--- a/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
@@ -1,0 +1,43 @@
+<?php
+namespace App\UseCase\UseCaseInteractor;
+
+use App\UseCase\UseCaseInput\SigninInput;
+use App\UseCase\UseCaseOutput\SigninOutput;
+use App\Infrastructure\Dao\LoginSessionDao;
+use App\Infrastructure\Dao\UserSqlDao;
+
+final class SigninInteractor
+{
+    const FAILED_MESSAGE = 'メールアドレスまたはパスワードが違います。';
+    const COMPLETE_MESSAGE = 'ログインしました。';
+
+    private $userDao;
+    private $input;
+
+    public function __construct(SigninInput $input)
+    {
+        $this->userDao = new UserSqlDao();
+        $this->input = $input;
+    }
+
+    public function handle(): SigninOutput
+    {
+        $user = $this->findUser();
+        if (is_null($user) || $this->isInvalidPassword($user['password'])) {
+            return new SigninOutput(false, self::FAILED_MESSAGE);
+        }
+        $loginDao = new LoginSessionDao();
+        $loginDao->setLoginUser($user['id'], $user['name']);
+        return new SigninOutput(true, self::COMPLETE_MESSAGE);
+    }
+
+    private function findUser(): ?array
+    {
+        return $this->userDao->findByMail($this->input->getEmail());
+    }
+
+    private function isInvalidPassword(string $password): bool
+    {
+        return !password_verify($this->input->getPassword(), $password);
+    }
+}

--- a/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
@@ -3,7 +3,7 @@ namespace App\UseCase\UseCaseInteractor;
 
 use App\UseCase\UseCaseInput\SigninInput;
 use App\UseCase\UseCaseOutput\SigninOutput;
-use App\Infrastructure\Dao\LoginSessionDao;
+use App\Infrastructure\Dao\AuthSessionDao;
 use App\Infrastructure\Dao\UserSqlDao;
 
 final class SigninInteractor
@@ -26,8 +26,8 @@ final class SigninInteractor
         if (is_null($user) || $this->isInvalidPassword($user['password'])) {
             return new SigninOutput(false, self::FAILED_MESSAGE);
         }
-        $loginDao = new LoginSessionDao();
-        $loginDao->setLoginUser($user['id'], $user['name']);
+        $authDao = new AuthSessionDao();
+        $authDao->setSigninUser($user['id'], $user['name']);
         return new SigninOutput(true, self::COMPLETE_MESSAGE);
     }
 

--- a/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SigninInteractor.php
@@ -20,6 +20,10 @@ final class SigninInteractor
         $this->input = $input;
     }
 
+    /**
+     * インタラクタ実行
+     * @return SigninOutput
+     */
     public function handle(): SigninOutput
     {
         $user = $this->findUser();
@@ -31,11 +35,20 @@ final class SigninInteractor
         return new SigninOutput(true, self::COMPLETE_MESSAGE);
     }
 
+    /**
+     * ユーザー取得
+     * @return array | null
+     */
     private function findUser(): ?array
     {
         return $this->userDao->findByMail($this->input->getEmail());
     }
 
+    /**
+     * パスワード認証
+     * @param string $password
+     * @return bool
+     */
     private function isInvalidPassword(string $password): bool
     {
         return !password_verify($this->input->getPassword(), $password);

--- a/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
@@ -1,0 +1,34 @@
+<?php
+namespace App\UseCase\UseCaseInteractor;
+
+use App\UseCase\UseCaseInput\SignupInput;
+use App\UseCase\UseCaseOutput\SignupOutput;
+use App\Infrastructure\Dao\UserSqlDao;
+
+final class SignupInteractor
+{
+    const ALREADY_EXIST_MESSAGE = '入力したメールアドレスは既に入力済みです。';
+    const COMPLETE_MESSAGE = '登録が完了しました。';
+
+    private $useCaseInput;
+
+    public function __construct(SignupInput $useCaseInput)
+    {
+        $this->useCaseInput = $useCaseInput;
+    }
+
+    public function handle(): SignupOutput
+    {
+        $userDAO = new UserSqlDao();
+        $name = $this->useCaseInput->getName();
+        $email = $this->useCaseInput->getEmail();
+        $password = $this->useCaseInput->getPassword();
+
+        $user = $userDAO->findByMail($email);
+        if (!is_null($user)) {
+            return new SignupOutput(false, self::ALREADY_EXIST_MESSAGE);
+        }
+        $userDAO->create($name, $email, $password);
+        return new SignupOutput(true, self::COMPLETE_MESSAGE);
+    }
+}

--- a/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
@@ -10,25 +10,35 @@ final class SignupInteractor
     const ALREADY_EXIST_MESSAGE = '入力したメールアドレスは既に入力済みです。';
     const COMPLETE_MESSAGE = '登録が完了しました。';
 
-    private $useCaseInput;
+    private $userDao;
+    private $input;
 
-    public function __construct(SignupInput $useCaseInput)
+    public function __construct(SignupInput $input)
     {
-        $this->useCaseInput = $useCaseInput;
+        $this->userDao = new UserSqlDao();
+        $this->input = $input;
     }
 
     public function handle(): SignupOutput
     {
-        $userDAO = new UserSqlDao();
-        $name = $this->useCaseInput->getName();
-        $email = $this->useCaseInput->getEmail();
-        $password = $this->useCaseInput->getPassword();
-
-        $user = $userDAO->findByMail($email);
+        $user = $this->findUser();
         if (!is_null($user)) {
             return new SignupOutput(false, self::ALREADY_EXIST_MESSAGE);
         }
-        $userDAO->create($name, $email, $password);
+        $this->createUser();
         return new SignupOutput(true, self::COMPLETE_MESSAGE);
+    }
+
+    private function findUser(): ?array
+    {
+        return $this->userDao->findByMail($this->input->getEmail());
+    }
+
+    private function createUser(): void
+    {
+        $name = $this->input->getName();
+        $email = $this->input->getEmail();
+        $password = $this->input->getPassword();
+        $this->userDao->create($name, $email, $password);
     }
 }

--- a/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
+++ b/src/app/Usecase/UsecaseInteractor/SignupInteractor.php
@@ -19,6 +19,10 @@ final class SignupInteractor
         $this->input = $input;
     }
 
+    /**
+     * インタラクタ実行
+     * @return SigninOutput
+     */
     public function handle(): SignupOutput
     {
         $user = $this->findUser();
@@ -29,11 +33,18 @@ final class SignupInteractor
         return new SignupOutput(true, self::COMPLETE_MESSAGE);
     }
 
+    /**
+     * ユーザー取得
+     * @return array | null
+     */
     private function findUser(): ?array
     {
         return $this->userDao->findByMail($this->input->getEmail());
     }
 
+    /**
+     * ユーザー作成
+     */
     private function createUser(): void
     {
         $name = $this->input->getName();

--- a/src/app/Usecase/UsecaseOutput/SigninOutput.php
+++ b/src/app/Usecase/UsecaseOutput/SigninOutput.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\UseCase\UseCaseOutput;
+
+final class SigninOutput
+{
+    private $isSuccess;
+    private $message;
+
+    public function __construct(bool $isSuccess, string $message)
+    {
+        $this->isSuccess = $isSuccess;
+        $this->message = $message;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->isSuccess;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/app/Usecase/UsecaseOutput/SigninOutput.php
+++ b/src/app/Usecase/UsecaseOutput/SigninOutput.php
@@ -12,11 +12,19 @@ final class SigninOutput
         $this->message = $message;
     }
 
+    /**
+     * インタラクト結果の取得
+     * @return bool
+     */
     public function isSuccess(): bool
     {
         return $this->isSuccess;
     }
 
+    /**
+     * インタラクトメッセージの取得
+     * @return string
+     */
     public function getMessage(): string
     {
         return $this->message;

--- a/src/app/Usecase/UsecaseOutput/SignupOutput.php
+++ b/src/app/Usecase/UsecaseOutput/SignupOutput.php
@@ -12,11 +12,19 @@ final class SignupOutput
         $this->message = $message;
     }
 
+    /**
+     * インタラクト結果の取得
+     * @return bool
+     */
     public function isSuccess(): bool
     {
         return $this->isSuccess;
     }
 
+    /**
+     * インタラクトメッセージの取得
+     * @return string
+     */
     public function getMessage(): string
     {
         return $this->message;

--- a/src/app/Usecase/UsecaseOutput/SignupOutput.php
+++ b/src/app/Usecase/UsecaseOutput/SignupOutput.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\UseCase\UseCaseOutput;
+
+final class SignupOutput
+{
+    private $isSuccess;
+    private $message;
+
+    public function __construct(bool $isSuccess, string $message)
+    {
+        $this->isSuccess = $isSuccess;
+        $this->message = $message;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->isSuccess;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/public/assets/css/style.css
+++ b/src/public/assets/css/style.css
@@ -17,3 +17,6 @@ body {
 .error {
   color: red;
 }
+.success {
+  color: green;
+}

--- a/src/public/includes/header.php
+++ b/src/public/includes/header.php
@@ -1,6 +1,6 @@
 <header id="masthead" class="header">
   <h1 class="header__logo">Blogアプリ</h1>
-  <form method="post" action="/logout.php">
+  <form method="post" action="/user/signout.php">
     <button>ログアウト</button>
   </form>
 </header>

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,11 +1,11 @@
 <?php
 require_once '../vendor/autoload.php';
 
-use App\Infrastructure\Dao\LoginSessionDao;
+use App\Infrastructure\Dao\AuthSessionDao;
 
 session_start();
-$loginDao = new LoginSessionDao();
-$user = $loginDao->getLoginUser();
+$authDao = new AuthSessionDao();
+$user = $authDao->getSigninUser();
 ?><!doctype html>
 <html>
 <head>

--- a/src/public/user/signin.php
+++ b/src/public/user/signin.php
@@ -4,7 +4,7 @@ require_once '../../vendor/autoload.php';
 use App\UseCase\UseCaseInput\SigninInput;
 use App\UseCase\UseCaseInteractor\SigninInteractor;
 use App\Infrastructure\Dao\MessagesSessionDao;
-use App\Infrastructure\Dao\LoginSessionDao;
+use App\Infrastructure\Dao\AuthSessionDao;
 use App\Exception\InputErrorExeception;
 use App\Utils\Response;
 use App\Utils\Validator;
@@ -16,8 +16,8 @@ $password = '';
 session_start();
 $messagesDao = new MessagesSessionDao();
 $messages = $messagesDao->getMessages();
-$loginDao = new LoginSessionDao();
-if (!is_null($loginDao->getLoginUser())) {
+$authDao = new AuthSessionDao();
+if (!is_null($authDao->getSigninUser())) {
     Response::redirect('../index.php');
 }
 

--- a/src/public/user/signin_complete.php
+++ b/src/public/user/signin_complete.php
@@ -1,0 +1,62 @@
+<?php
+require_once '../../vendor/autoload.php';
+
+use App\UseCase\UseCaseInput\SigninInput;
+use App\UseCase\UseCaseInteractor\SigninInteractor;
+use App\Infrastructure\Dao\MessagesSessionDao;
+use App\Infrastructure\Dao\FormDataSessionDao;
+use App\Infrastructure\Dao\ErrorsSessionDao;
+use App\Exception\InputErrorExeception;
+use App\Utils\Response;
+use App\Utils\Validator;
+
+// GETでのアクセス防止
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    Response::redirect('./signin.php');
+}
+
+$errors = [];
+$email = Validator::sanitize(filter_input(INPUT_POST, 'email') ?? '');
+$password = Validator::sanitize(filter_input(INPUT_POST, 'password') ?? '');
+
+try {
+    session_start();
+    if (!Validator::isNotBlank($email)) {
+        $errors['email'] = 'メールアドレスを入力してください。';
+    }
+    if (!Validator::isNotBlank($password)) {
+        $errors['password'] = 'パスワードを入力してください。';
+    }
+    if (!empty($errors)) {
+        throw (new InputErrorExeception(
+            '入力された値に誤りがあります',
+            400
+        ))->setErrors($errors);
+    }
+
+    $input = new SigninInput($email, $password);
+    $usecase = new SigninInteractor($input);
+    $output = $usecase->handle();
+
+    if (!$output->isSuccess()) {
+        throw (new InputErrorExeception(
+            '入力された値に誤りがあります',
+            400
+        ))->setErrors(['system' => $output->getMessage()]);
+    }
+
+    $messagesDao = new MessagesSessionDao();
+    $messagesDao->setMessage($output->getMessage());
+    Response::redirect('../index.php');
+} catch (InputErrorExeception $e) {
+    $formDataDao = new FormDataSessionDao();
+    $errorsDao = new ErrorsSessionDao();
+
+    $formData = compact('email', 'password');
+    $formDataDao->setFormData($formData);
+
+    $errors = array_merge($errors, $e->getErrors());
+    $errorsDao->setErrors($errors);
+
+    Response::redirect('./signin.php');
+}

--- a/src/public/user/signout.php
+++ b/src/public/user/signout.php
@@ -1,11 +1,11 @@
 <?php
-require_once '../vendor/autoload.php';
+require_once '../../vendor/autoload.php';
 
 use App\Utils\Response;
 
 // GETでのアクセス防止
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    Response::redirect('./index.php');
+    Response::redirect('../index.php');
 }
 
 session_start();
@@ -14,4 +14,4 @@ if (isset($_COOKIE[session_name()])) {
     setcookie(session_name(), '', time() - 3600, '/');
 }
 session_destroy();
-Response::redirect('./user/signin.php');
+Response::redirect('./signin.php');

--- a/src/public/user/signup.php
+++ b/src/public/user/signup.php
@@ -1,9 +1,9 @@
 <?php
 require_once '../../vendor/autoload.php';
 
-use App\Infrastructure\Dao\UserSqlDao;
 use App\UseCase\UseCaseInput\SignupInput;
 use App\UseCase\UseCaseInteractor\SignupInteractor;
+use App\Infrastructure\Dao\MessagesSessionDao;
 use App\Exception\InputErrorExeception;
 use App\Utils\Response;
 use App\Utils\Validator;
@@ -13,6 +13,9 @@ $name = '';
 $email = '';
 $password = '';
 $passwordConfirm = '';
+
+session_start();
+$messagesDao = new MessagesSessionDao();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
@@ -42,17 +45,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ))->setErrors($errors);
         }
 
-        $useCaseInput = new SignupInput($name, $email, $password);
-        $useCase = new SignupInteractor($useCaseInput);
-        $useCaseOutput = $useCase->handle();
+        $input = new SignupInput($name, $email, $password);
+        $usecase = new SignupInteractor($input);
+        $output = $usecase->handle();
 
-        if (!$useCaseOutput->isSuccess()) {
+        if (!$output->isSuccess()) {
             throw (new InputErrorExeception(
                 '入力された値に誤りがあります',
                 400
-            ))->setErrors(['email' => $useCaseOutput->getMessage()]);
+            ))->setErrors(['email' => $output->getMessage()]);
         }
-        $_SESSION['flash'][] = $useCaseOutput->getMessage();
+        $messagesDao->setMessage($output->getMessage());
         Response::redirect('./signin.php');
     } catch (InputErrorExeception $e) {
         $errors = array_merge($errors, $e->getErrors());
@@ -75,25 +78,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <div>
         <input name="name" placeholder="ユーザー名" maxlength="255" value="<?php echo $name; ?>">
 <?php if (!empty($errors['name'])): ?>
-        <div class="error"><?php echo $errors['name']; ?>
+        <div class="error"><?php echo $errors['name']; ?></div>
 <?php endif; ?>
       </div>
       <div>
         <input name="email" placeholder="メールアドレス" maxlength="255" value="<?php echo $email; ?>">
 <?php if (!empty($errors['email'])): ?>
-        <div class="error"><?php echo $errors['email']; ?>
+        <div class="error"><?php echo $errors['email']; ?></div>
 <?php endif; ?>
       </div>
       <div>
         <input type="password" name="password" placeholder="Password" maxlength="20" value="<?php echo $password; ?>">
 <?php if (!empty($errors['password'])): ?>
-        <div class="error"><?php echo $errors['password']; ?>
+        <div class="error"><?php echo $errors['password']; ?></div>
 <?php endif; ?>
       </div>
       <div>
         <input type="password" name="password_confirm" placeholder="Password確認" maxlength="20" value="<?php echo $passwordConfirm; ?>">
 <?php if (!empty($errors['passwordConfirm'])): ?>
-        <div class="error"><?php echo $errors['passwordConfirm']; ?>
+        <div class="error"><?php echo $errors['passwordConfirm']; ?></div>
 <?php endif; ?>
       </div>
       <div>

--- a/src/public/user/signup_complete.php
+++ b/src/public/user/signup_complete.php
@@ -1,0 +1,71 @@
+<?php
+require_once '../../vendor/autoload.php';
+
+use App\UseCase\UseCaseInput\SignupInput;
+use App\UseCase\UseCaseInteractor\SignupInteractor;
+use App\Infrastructure\Dao\MessagesSessionDao;
+use App\Infrastructure\Dao\FormDataSessionDao;
+use App\Infrastructure\Dao\ErrorsSessionDao;
+use App\Exception\InputErrorExeception;
+use App\Utils\Response;
+use App\Utils\Validator;
+
+// GETでのアクセス防止
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    Response::redirect('./signup.php');
+}
+
+$errors = [];
+$name = Validator::sanitize(filter_input(INPUT_POST, 'name') ?? '');
+$email = Validator::sanitize(filter_input(INPUT_POST, 'email') ?? '');
+$password = Validator::sanitize(filter_input(INPUT_POST, 'password') ?? '');
+$passwordConfirm = Validator::sanitize(
+    filter_input(INPUT_POST, 'passwordConfirm') ?? ''
+);
+
+try {
+    session_start();
+    if (!Validator::isNotBlank($name)) {
+        $errors['name'] = 'ユーザー名を入力してください。';
+    }
+    if (!Validator::isNotBlank($email)) {
+        $errors['email'] = 'メールアドレスを入力してください。';
+    }
+    if (!Validator::isNotBlank($password)) {
+        $errors['password'] = 'パスワードを入力してください。';
+    } elseif (!Validator::isMatch($password, $passwordConfirm)) {
+        $errors['passwordConfirm'] = 'パスワードが一致しません。';
+    }
+    if (!empty($errors)) {
+        throw (new InputErrorExeception(
+            '入力された値に誤りがあります',
+            400
+        ))->setErrors($errors);
+    }
+
+    $input = new SignupInput($name, $email, $password);
+    $usecase = new SignupInteractor($input);
+    $output = $usecase->handle();
+
+    if (!$output->isSuccess()) {
+        throw (new InputErrorExeception(
+            '入力された値に誤りがあります',
+            400
+        ))->setErrors(['email' => $output->getMessage()]);
+    }
+
+    $messagesDao = new MessagesSessionDao();
+    $messagesDao->setMessage($output->getMessage());
+    Response::redirect('./signin.php');
+} catch (InputErrorExeception $e) {
+    $formDataDao = new FormDataSessionDao();
+    $errorsDao = new ErrorsSessionDao();
+
+    $formData = compact('name', 'email', 'password', 'passwordConfirm');
+    $formDataDao->setFormData($formData);
+
+    $errors = array_merge($errors, $e->getErrors());
+    $errorsDao->setErrors($errors);
+
+    Response::redirect('./signup.php');
+}


### PR DESCRIPTION
## 【作業内容】
Usecaseパターンで処理を分割させる。

## 【特記事項】
- 入力エラーを連想配列で取り扱いたいなと思って、 `InputErrorExeception` を作成しました。
- Session関連はDaoを作成して対応をしました。
- signoutの処理もUsecaseを作成してみようとしましたが、input,outputが無く過剰実装になるかなと思って一旦ママにしています。

## 【気になる点】
- signup.php, signin.phpが複雑になってきたのが気になっています。Presenter, ViewModelあたりで綺麗にしていきたい。
- Daoの使用箇所が散ってしまっている
  - セッションまわりのDaoを作ってみたはいいけど、処理の関係上interactorとpublic配下のphpの両方で使用してしまっている。依存関係の流れ的にあまり良くないのかな？と感じているので、一通りDDDでの作成を終えた段階で再度整理していきたい。